### PR TITLE
add type cast in x11_window

### DIFF
--- a/source/glfw3/x11_window.d
+++ b/source/glfw3/x11_window.d
@@ -148,7 +148,7 @@ private int getWindowState(_GLFWwindow* window) {
                                   _glfw.x11.WM_STATE,
                                   cast(ubyte**) &state) >= 2)
     {
-        result = state.state;
+        result = cast(int)state.state;
     }
 
     if (state)


### PR DESCRIPTION
This is needed when compiling on some devices like raspberry-pi and jetson-nano